### PR TITLE
Fixed space error #2. Documented shammy.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,10 @@ With the code above, given that the files are present where we specified in our 
 ## CHANGE LOG
 
 ### 6/10/2016
+- v0.0.6 | Fixed error caused by *multiple* spaces preceding '/>' & Documented shammy.js
+
 - v0.0.5 | Fixed greedy match error.
-- v0.0.4 | Fixed error caused by space preceeding '/>'.
+- v0.0.4 | Fixed error caused by space preceding '/>'.
 - v0.0.3 | Added support for script `async` and `defer` attributes.
 - v0.0.2 | Fixed undiagnosed `unidentified` error.
 - v0.0.1 | Initial release.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shammy",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Shammy takes a HTML file and absorbs its local dependencies so that only one http request is necessary to present the page to the client.",
   "main": "shammy.js",
   "scripts": {

--- a/shammy.js
+++ b/shammy.js
@@ -1,25 +1,47 @@
 const FILES = require('fs');
 
 module.exports = {
+
+  // TODO: Add support for async file read.
+
+/* GUIDE //////////////////////////////////////
+
+  |1| Retrieve data contained inside user-specified file.
+
+  |2| For each <absorb ... /> elements found in the file...
+
+      |- Remove excess space before tag close. (i.e 'app.js"__/>')
+      |- Determine if absorbed data needs <style> or <script> tags.
+      |
+      |----- CSS? Slice file path from css attribute, retrieve file contents,
+      |      and replace <absorb> element with the data inside <style> tags.
+      |
+      |----- JS? Slice file path from js attribute, retrieve file contents,
+      |      and replace <absorb> element with the data inside <script> tags.
+      |      + IF <absorb> element contained async or defer attribute indicators,
+      |      + add the async|defer attribute inside of opening <script> tag.
+      |
+      |----- OTHERWISE, place <script> containing invalidity alert.
+
+  |3| Return modified file.
+
+*/
+
   absorb: (htmlPath) => {
     let htmlNew = FILES.readFileSync(htmlPath, 'utf8');
     let htmlReturn = htmlNew.replace(/(<absorb\s(.+?)\/>)/g, function(absorbEl) {
       let filePath = '', fileType = '', jsMod = '';
-
-      if (absorbEl.indexOf(' />')) absorbEl = absorbEl.replace(/('|")\s\/>/g, '\'/>');
-
-      if (absorbEl.indexOf('css=') >= 0) {
+      if (absorbEl.search(/('|")(\s+)\/>/g)) absorbEl = absorbEl.replace(/('|")(\s+)\/>/g, '\'/>');
+      if (absorbEl.includes('css=')) {
         fileType = 'css';
         filePath = absorbEl.slice(
           absorbEl.indexOf('css=') + 5,
           absorbEl.indexOf('/>') - 1
         ); // filePath
-
-      } else if (absorbEl.indexOf('js=') >= 0) {
-        if (absorbEl.indexOf(' defer ') > 0 | absorbEl.indexOf('defer="defer"') > 0) jsMod = ' defer';
-        else if (absorbEl.indexOf(' async ') > 0) jsMod = ' async';
+      } else if (absorbEl.includes('js=')) {
+        if (absorbEl.includes(' defer')) jsMod = ' defer';
+        else if (absorbEl.includes(' async')) jsMod = ' async';
         else jsMod = '';
-        // console.log(jsMod);
         fileType = 'js';
         filePath = absorbEl.slice(
           absorbEl.indexOf('js=') + 4,
@@ -31,7 +53,6 @@ module.exports = {
       else if (fileType == 'js') return `<script${jsMod}>${code}</script>`;
       else return `<script async>alert('ERR: ${filePath}')</script>`;
     }); // html.replace()
-
     return htmlReturn;
   } // absorb()
 }; // module.exports


### PR DESCRIPTION
I had previously fixed the error that was caused by a single space found before the closing of the absorb tag, as seen here:

`<absorb css="./path/to/this.css" />`

This patch adds support for any amount of space found at that location and also adds documentation to `shammy.js`.
